### PR TITLE
Add the upper-bound of redis gem

### DIFF
--- a/redis-elasticache.gemspec
+++ b/redis-elasticache.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "redis", ">= 3.0.0"
+  spec.add_dependency "redis", ">= 3.0.0", "<= 4.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Hi,

I had experienced ElasticCache failover  and found this gem solved the issue by reproducing same failovers in our environment with help by AWS support team.

Now my team is planning to use this gem ( thanks for creating this gem!) but want to propose a PR to ensure this gem works with designated version of redis gem. 

Our purpose of the PR is to ensure the existence of the method which this gem override. Because I thought that dynamic checking the existence of a method looks overweighted, I added the version checking in gemspec.