### PR TITLE
Support Sidekiq and handle LOADING

### DIFF
--- a/lib/redis/elasticache/failover.rb
+++ b/lib/redis/elasticache/failover.rb
@@ -6,7 +6,7 @@ class Redis
     class Ruby
 
       ELASTICACHE_READONLY_ERROR = "READONLY You can't write against a read only slave.".freeze
-      ELASTICACHE_READONLY_MESSAGE = "A write operation was issued to an ELASTICACHE slave node.".freeze
+      ELASTICACHE_READONLY_MESSAGE = "A write operation was issued to an ELASTICACHE slave node that is READONLY.".freeze
 
       # Amazon RDS supports failover, but because it uses DNS magic to point to
       # the master node, TCP connections are not disconnected and we can issue

--- a/lib/redis/elasticache/failover.rb
+++ b/lib/redis/elasticache/failover.rb
@@ -6,7 +6,9 @@ class Redis
     class Ruby
 
       ELASTICACHE_READONLY_ERROR = "READONLY You can't write against a read only slave.".freeze
+      ELASTICACHE_LOADING_ERROR = "LOADING Redis is loading the dataset in memory".freeze
       ELASTICACHE_READONLY_MESSAGE = "A write operation was issued to an ELASTICACHE slave node that is READONLY.".freeze
+      ELASTICACHE_LOADING_MESSAGE = "A write operation was issued to an ELASTICACHE node that was previously READONLY and is now LOADING.".freeze
 
       # Amazon RDS supports failover, but because it uses DNS magic to point to
       # the master node, TCP connections are not disconnected and we can issue
@@ -19,6 +21,8 @@ class Redis
         error_message = line.strip
         if error_message == ELASTICACHE_READONLY_ERROR
           raise BaseConnectionError, ELASTICACHE_READONLY_MESSAGE
+        elsif error_message == ELASTICACHE_LOADING_ERROR
+          raise BaseConnectionError, ELASTICACHE_LOADING_MESSAGE
         else
           CommandError.new(error_message)
         end

--- a/lib/redis/elasticache/version.rb
+++ b/lib/redis/elasticache/version.rb
@@ -1,5 +1,5 @@
 class Redis
   module Elasticache
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end

--- a/lib/redis/elasticache/version.rb
+++ b/lib/redis/elasticache/version.rb
@@ -1,5 +1,5 @@
 class Redis
   module Elasticache
-    VERSION = "0.1.2"
+    VERSION = "0.1.3"
   end
 end


### PR DESCRIPTION
@craigmcnamara , thank you for this gem.  It really helped us.  I have added two more conditions that you may want to consider handling.

1) Sidekiq expects to see READONLY in the CommandError in order to trigger a retry.  I have added READONLY to the new message reported.  See https://github.com/mperham/sidekiq/blob/master/lib/sidekiq.rb#L99

2) There is also the case where a cluster gets made primary and, with a lot of data, is still loading data into memory when it gets hit.  I add handling this case.

I bumped our version twice because LOADING was added after testing the first version bump.