### PR TITLE
Check error prefix for READONLY and LOADING

### DIFF
--- a/spec/redis/elasticache_spec.rb
+++ b/spec/redis/elasticache_spec.rb
@@ -8,10 +8,26 @@ describe Redis::Elasticache do
   context 'Redis::Connection::Ruby#format_error_reply failover patch' do
 
     let(:connection) { Redis::Connection::Ruby.new nil }
-    let(:read_only_response) { "READONLY You can't write against a read only replica." }
+
+    let(:read_only_response1) { "READONLY You can't write against a read only replica." }
+    let(:read_only_response2) { "READONLY You can't write against a read only slave." }
+    let(:read_only_response3) { "READONLY unkown error message." }
+    let(:loading_response1) { "LOADING unkown error message." }
 
     it 'raises `BaseConnectionError` when a write occurs against a replica node' do
-      expect { connection.format_error_reply read_only_response }.to raise_error Redis::BaseConnectionError
+      expect { connection.format_error_reply read_only_response1 }.to raise_error Redis::BaseConnectionError
+    end
+
+    it 'raises `BaseConnectionError` when a write occurs against a slave node' do
+      expect { connection.format_error_reply read_only_response2 }.to raise_error Redis::BaseConnectionError
+    end
+
+    it 'raises `BaseConnectionError` when error message having the READONLY prefix' do
+      expect { connection.format_error_reply read_only_response3 }.to raise_error Redis::BaseConnectionError
+    end
+
+    it 'raises `BaseConnectionError` when error message having the LOADING prefix' do
+      expect { connection.format_error_reply loading_response1 }.to raise_error Redis::BaseConnectionError
     end
 
     it 'returns a `CommandError` in all other cases' do


### PR DESCRIPTION
+ Handle the error message
READONLY You can't write against a read only slave.

Its enough to check only error prefix ref:
https://github.com/luin/ioredis/pull/148/files
https://github.com/contribsys/faktory/commit/ac4cd80f4dee4b50d53cf111c54f92d15bc1be46

Fix for https://github.com/craigmcnamara/redis-elasticache/issues/8