### PR TITLE
adjust wording in comment and use elasticache instead of rds

### DIFF
--- a/lib/redis/elasticache/failover.rb
+++ b/lib/redis/elasticache/failover.rb
@@ -10,12 +10,12 @@ class Redis
       ELASTICACHE_READONLY_MESSAGE = "A write operation was issued to an ELASTICACHE replica node that is READONLY.".freeze
       ELASTICACHE_LOADING_MESSAGE = "A write operation was issued to an ELASTICACHE node that was previously READONLY and is now LOADING.".freeze
 
-      # Amazon RDS supports failover, but because it uses DNS magic to point to
-      # the master node, TCP connections are not disconnected and we can issue
-      # write operations to a node that is no longer the master. Under normal 
-      # conditions this should be interpreted as a `CommandError`, but with RDS
-      # replication groups, we should consider this a `BaseConnectionError` so we
-      # terminate the connection, reconnect and retry the operation with the
+      # Amazon Elasticache supports failover, but because it uses DNS magic to
+      # point to the master node, TCP connections are not disconnected and we
+      # can issue write operations to a node that is no longer the master. Under
+      # normal conditions this should be interpreted as a `CommandError`, but with
+      # Elasticache replication groups, we should consider this a `BaseConnectionError`
+      # so we terminate the connection, reconnect and retry the operation with the
       # correct node as the master accepting writes.
       def format_error_reply(line)
         error_message = line.strip


### PR DESCRIPTION
Adjusted wording in comment and aligned it with the change that was in #3.